### PR TITLE
Enable configuration from home directory

### DIFF
--- a/magpie/config/__init__.py
+++ b/magpie/config/__init__.py
@@ -1,9 +1,12 @@
 from os import path
 
 class ConfigPath(object):
+    def __init__(self):
+        self.config_paths = [path.join(path.expanduser('~'), '.magpie'), path.dirname(__file__)]
     def __getattr__(self, key):
-        return_path = path.join(path.dirname(__file__), key + '.cfg')
-        if not path.exists(return_path): return None
-        return return_path
+        for path in self.config_paths:
+            return_path = path.join(path, key + '.cfg')
+            if path.exists(return_path): return return_path
+        return None
 
 config_path = ConfigPath()


### PR DESCRIPTION
This adds the possibility of defining multiple locations for the config-files. The given example first searches in ~/.magpie and if it doesn't find any config-files there, it searches in the default path. This enables configuration for each individual user and fixes the problem that magpie must be run as root if it was installed as root.

This (most likely?) fixes https://github.com/charlesthomas/magpie/issues/1
