### PR TITLE
update variable name path, to path_str

### DIFF
--- a/magpie/config/__init__.py
+++ b/magpie/config/__init__.py
@@ -4,8 +4,8 @@ class ConfigPath(object):
     def __init__(self):
         self.config_paths = [path.join(path.expanduser('~'), '.magpie'), path.dirname(__file__)]
     def __getattr__(self, key):
-        for path in self.config_paths:
-            return_path = path.join(path, key + '.cfg')
+        for path_str in self.config_paths:
+            return_path = path.join(path_str, key + '.cfg')
             if path.exists(return_path): return return_path
         return None
 


### PR DESCRIPTION
Avoid confusing on os.path and string path.

orig. execution failed on my ENV:: 

```
python-2.7.1-7.fc15.i686 
magpie-0.0.4-py2.7.egg
```

just change the name and it now works.
