### PR TITLE
add option to specify server listen address

### DIFF
--- a/magpie/config/web.cfg
+++ b/magpie/config/web.cfg
@@ -1,4 +1,5 @@
 port=8080
+address='localhost'
 testing=False
 autosave=False
 repo='/path/to/notes/repo/'

--- a/magpie/server.py
+++ b/magpie/server.py
@@ -30,6 +30,7 @@ app_config = dict(static_path=static_path,
                   login_url='/login')
 
 define('port', default='8080', type=int)
+define('address', default='localhost', type=str)
 define('testing', default=False, type=bool)
 define('repo', default=None, type=str)
 define('username', default=None, type=str)
@@ -49,13 +50,11 @@ server.settings.pwdhash = options.pwdhash
 server.settings.session = _rand_str()
 server.settings.config_path = config_path
 server.settings.autosave = options.autosave
+server.settings.address = options.address
 
 def main():
     server.git = git.bake(_cwd=server.settings.repo)
-    if options.listen_localhost_only:
-        server.listen(options.port, 'localhost')
-    else:
-        server.listen(options.port)
+    server.listen(options.port, server.settings.address)
     autoreload.start()
     autoreload.watch(config_path.web)
     IOLoop.instance().start()


### PR DESCRIPTION
Instead of being limited to all interfaces or localhost only, give the option to specify the address the server should listen on.  IP address or DNS name should work here.  0.0.0.0 means to listen on any interface.
