### PR TITLE
Fixes #6 Searching through notes that includes unicode characters.

### DIFF
--- a/magpie/handler/base.py
+++ b/magpie/handler/base.py
@@ -46,9 +46,9 @@ class BaseHandler(RequestHandler):
         return sorted(starred) + sorted(unstarred)
 
     def highlight(self, text, highlight):
-        return text.replace(highlight,
+        return text.replace(highlight.encode('utf8'),
                             "<font style=background-color:yellow>%s</font>" % \
-                            highlight)
+                            highlight.encode('utf8'))
 
     def get_current_user(self):
         if self.settings.username is None and self.settings.pwdhash is None \


### PR DESCRIPTION
Fixes an internal error 500 when searching through notes that includes unicode characters. 
