### PR TITLE
Fix notebook path and creation errors

### DIFF
--- a/magpie/handler/notebook.py
+++ b/magpie/handler/notebook.py
@@ -7,13 +7,13 @@ from base import BaseHandler
 class NotebookHandler(BaseHandler):
     @authenticated
     def get(self, notebook_name):
+        if notebook_name.endswith('/'):
+            notebook_name = notebook_name[:-1]
         notebook_name = self.encode_name(notebook_name)
 
         if not path.isdir(path.join(self.settings.repo, notebook_name)):
             self.redirect('/')
         else:
-            if notebook_name.endswith('/'):
-                notebook_name = notebook_name[:-1]
             notebook_path = path.join(self.settings.repo, notebook_name)
             notebook_contents = listdir(notebook_path)
             if '.git' in notebook_contents:
@@ -23,8 +23,11 @@ class NotebookHandler(BaseHandler):
 
     @authenticated
     def post(self, notebook_name):
+        if notebook_name.endswith('/'):
+            notebook_name = notebook_name[:-1]
         notebook_name = self.encode_name(notebook_name)
 
         notebook_path = path.join(self.settings.repo, notebook_name)
-        makedirs(notebook_path)
+        if not path.exists(notebook_path):
+            makedirs(notebook_path)
         self.finish()


### PR DESCRIPTION
Fix issues with trailing "/" in notebook paths
Check if directory already exists before attempting to create it to prevent exceptions
