### PR TITLE
Added support for MathJax via markdown2mathjax.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,12 @@
 argparse==1.2.1
 backports.ssl-match-hostname==3.4.0.2
+dulwich==0.9.7
 filemagic==1.6
 markdown2==2.2.1
+markdown2Mathjax==0.3.8
+nose==1.3.4
 py-bcrypt==0.4
 pyPdf==1.13
 sh==1.09
 tornado==3.2
 wsgiref==0.1.2
-dulwich==0.9.7

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -49,3 +49,15 @@ class Test(BaseTest):
                         note='this is a test note')
         test_path = path.join(self.notebook_path, note_name)
         self.assertTrue(path.exists(test_path))
+
+    def test_create_latex_note(self):
+        note_name = 'test_latex_note'
+        note_content = '*test* _latex_ '
+        latex_content = '$a_1*\\foo$'
+        res = self.post(self.notebook_url + note_name,
+                        allow_errors=True,
+                        save=True,
+                        note=note_content + latex_content)
+        test_path = path.join(self.notebook_path, note_name)
+        self.assertTrue(note_content not in self.get(self.notebook_url + note_name).body)
+        self.assertTrue(latex_content in self.get(self.notebook_url + note_name).body)


### PR DESCRIPTION
# PROS
  * This allows a note to contain inline latex, without excessive escaping.
  * It does *not* actually render the latex, it only stops markdown from parsing it.

# CONS
  * Adds a dependency to markdown2
  * Should probably have a configuration option to enable / disable the markdown2latex steps.