### PR TITLE
Added support for custom paths.

### DIFF
--- a/magpie/config/web.cfg
+++ b/magpie/config/web.cfg
@@ -5,3 +5,7 @@ autosave=False
 repo='/path/to/notes/repo/'
 username=''
 pwdhash=''
+enable_custom_template=False
+custom_template=''
+enable_custom_static=False
+custom_static=''

--- a/magpie/handler/config.py
+++ b/magpie/handler/config.py
@@ -7,7 +7,9 @@ from base import BaseHandler
 
 class ConfigHandler(BaseHandler):
     ALLOWED = {'testing': bool, 'port': int, 'pwdhash': str, 'repo': str,
-               'username': str, 'autosave': bool, 'address': str, 'wysiwyg' : bool}
+               'username': str, 'autosave': bool, 'address': str, 'wysiwyg' : bool,
+               'enable_custom_static': bool, 'enable_custom_template': bool, 'custom_static': str, 'custom_template': str}
+
     @authenticated
     def get(self):
         self.render('config.html', config=self._fetch_existing_config())

--- a/magpie/server.py
+++ b/magpie/server.py
@@ -23,15 +23,13 @@ def _rand_str(length=64):
 
 def make_app(config=None):
     root = path.dirname(__file__)
-    static_path = path.join(root, 'static')
-    template_path = path.join(root, 'template')
-
-    app_config = dict(static_path=static_path,
-                      template_path=template_path,
-                      login_url='/login')
 
     define('port', default='8080', type=int)
     define('address', default='localhost', type=str)
+    define('custom_static', default='', type=str)
+    define('custom_template', default='', type=str)
+    define('enable_custom_static', default=False, type=bool)
+    define('enable_custom_template', default=False, type=bool)
     define('testing', default=False, type=bool)
     define('repo', default=None, type=str)
     define('username', default=None, type=str)
@@ -44,6 +42,20 @@ def make_app(config=None):
         parse_config_file(config)
     else:
         parse_config_file(config_path.web)
+
+    if options.enable_custom_static:
+        static_path = options.custom_static or path.join(root, 'static')
+    else:
+        static_path = path.join(root, 'static')
+
+    if options.enable_custom_template:
+        template_path = options.custom_template or path.join(root, 'template')
+    else:
+        template_path = path.join(root, 'template')
+
+    app_config = dict(static_path=static_path,
+                      template_path=template_path,
+                      login_url='/login')
 
     if options.testing:
         app_config.update(debug=True)

--- a/magpie/template/config.html
+++ b/magpie/template/config.html
@@ -46,6 +46,28 @@
   </div>
   <div class="form-group">
     <label>
+      <input type="checkbox" name="enable_custom_static"{% if config.get('enable_custom_static', 'False') == 'True' %} checked="on"{% end if %} />
+        Enable custom static path
+    </label>
+  </div>
+  <div class="form-group">
+    <label class=control-label for=custom_static>Custom Static Path</label>
+      <input type="text" class=form-control name="custom_static" value="{{ config['custom_static'] }}" placeholder="Custom Static Path"/> 
+      <span class=help-block>Static assets will be served from this path, instead of the default static assets.</span>
+  </div>
+  <div class="form-group">
+    <label>
+      <input type="checkbox" name="enable_custom_template"{% if config.get('enable_custom_template', 'False') == 'True' %} checked="on"{% end if %} />
+        Enable custom template path
+    </label>
+  </div>
+  <div class="form-group">
+    <label class=control-label for=custom_template>Custom Template Path</label>
+      <input type="text" class=form-control name="custom_template" value="{{ config['custom_template'] }}" placeholder="Custom Template Path"/> 
+      <span class=help-block>Templates will be served from this path, instead of the default templates.</span>
+  </div>
+  <div class="form-group">
+    <label>
       <input type="checkbox" name="testing"{% if config.get('testing', 'False') == 'True' %} checked="on"{% end if %} /> Test Mode
     </label>
     <span class="help-block">Enables logging, you probably want to leave this off.</span>


### PR DESCRIPTION
Custom paths for static files and custom templates can be given from the
config.html page.

---

Originally I wanted this to allow new files and overrides, and I know how this can be accomplished in Flask/Jinja2 or Django, but I did not see a straightforward way of doing this in Tornado, so I only added functionality to completely replace the current paths.

Also, it would be nice to add a little javascript to the UI for these options to disable the fields when the checkboxs are unchecked, but as there is currently no JS driving the UI, I thought such a change would be out of scope.