### PR TITLE
Add dirty-flag for editing notes

### DIFF
--- a/magpie/template/note.html
+++ b/magpie/template/note.html
@@ -78,14 +78,19 @@ onload="checkbox_replace(document.getElementById('rendered_note'))";
     {% if autosave %}
         <script>
           var autosave = function(){
-            $.ajax({
-               url:  "{{ url_escape(note_name) }}?a=edit"
-              ,type: "POST"
-              ,data: {
-                 save: "Save"
-                ,note: $("textarea").val()
-              }
-            });
+            if (dirty) {
+              $.ajax({
+                 url:  "{{ url_escape(note_name) }}?a=edit"
+                ,type: "POST"
+                ,data: {
+                   save: "Save"
+                  ,note: $("textarea").val()
+                }
+                ,success: function(data, textStatus, jqXHR) {
+                   setDirty(false);
+                }
+              });
+            }
           };
           setInterval(autosave, 5000);
         </script>

--- a/magpie/template/note.html
+++ b/magpie/template/note.html
@@ -30,6 +30,20 @@
         $("#savefail").removeClass("hidden");
       });
     }
+    var dirty = false;
+    function setDirty(val) {
+      if (dirty != val) {
+        // on change
+        dirty = val;
+        if (dirty) {
+          // on dirty
+          document.title = "*" + document.title
+        } else {
+          // on clean
+          document.title = document.title.substr(1)
+        }
+      }
+    }
   </script>
 {% end block %}
 
@@ -60,7 +74,7 @@ onload="checkbox_replace(document.getElementById('rendered_note'))";
 
       </div>
     {% end if %}
-    <textarea cols=100 rows=25 name=note tabindex=1{% if wysiwyg %} class="hidden"{% end if %}>{{ note_contents }}</textarea>
+    <textarea cols=100 rows=25 name=note tabindex=1{% if wysiwyg %} class="hidden"{% end if %} oninput="setDirty(true);">{{ note_contents }}</textarea>
     {% if autosave %}
         <script>
           var autosave = function(){


### PR DESCRIPTION
Now, the note editing UI knows if you've made any changes. 

This could be useful to make an "are you sure you want to abandoned your unsaved changes" dialog and such. Autosave now only triggers when a note is dirty. 

So far, the only visible change is an asterisk appearing in the page title when a note is dirty. The asterisk vanishes on autosaves. 