### PR TITLE
Add feature to rename notes

### DIFF
--- a/magpie/handler/note.py
+++ b/magpie/handler/note.py
@@ -176,7 +176,7 @@ class NoteHandler(BaseHandler):
         if bool(self.get_argument('save', False)):
             note = self.get_argument('note')
             toggle = self.get_argument('toggle', -1)
-            note_name_rename = self.get_argument('note_name_rename')
+            note_name_rename = self.get_argument('note_name_rename', None)
             self._edit(notebook_name=notebook_name, note_name=note_name,
                        note_contents=note, confirmed=True, toggle=toggle, note_name_rename=note_name_rename)
         elif bool(self.get_argument('delete', False)):

--- a/magpie/template/note.html
+++ b/magpie/template/note.html
@@ -47,6 +47,9 @@ onload="checkbox_replace(document.getElementById('rendered_note'))";
     <br>
     <button class="btn btn-primary visible-xs" onclick="$('.row-offcanvas').toggleClass('active');">Notes</button>
     <form method=POST>
+    <input type="text" name="note_name_rename" value="{{ note_name }}" >
+    <br>
+    <br>
     <input type=submit class="btn btn-success" value=Save name=save>
     <input type=submit class="btn btn-danger" value=Cancel name=cancel>
     <br>

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -59,3 +59,30 @@ class Test(BaseTest):
         self.assertTrue('removing %s' % full_path in log[4])
         self.assertTrue(log[12].startswith('-%s' % note_text),
                         msg=log[12])
+
+    def test_renaming_note_renames_in_git(self):
+        note_name = 'mv_note_src'
+        note_dest_name = 'mv_note_dest'
+        note_text = 'this should be renamed in git'
+
+        # make note
+        res = self.post('/%s/%s' % (self.notebook_name, note_name),
+                        save=True,
+                        note=note_text)
+
+        # rename note
+        res = self.post('/%s/%s' % (self.notebook_name, note_name),
+                        save=True,
+                        confirmed=True,
+                        note=note_text,
+                        note_name_rename=note_dest_name)
+
+        log = self.fetch_log()
+        full_src_path = path.join(self.path, self.notebook_name, note_name)
+        full_dest_path = path.join(self.path, self.notebook_name, note_dest_name)
+        self.assertTrue('moving %s to %s' % (full_src_path, full_dest_path) in log[4])
+        # expecting content inserted into one and removed from the other
+        self.assertTrue(log[12].startswith('+%s' % note_text),
+                        msg="Expecting '%s' to start with '+'" % log[12])
+        self.assertTrue(log[20].startswith('-%s' % note_text),
+                        msg="Expecting '%s' to start with '-'" % log[20])

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -8,7 +8,7 @@ class Test(BaseTest):
     def setUp(self):
         super(Test, self).setUp()
 
-        self.git = git.bake(_cwd=self.path)
+        self.git = git.bake(_cwd=self.path, _tty_out=False)
         self.notebook_name = 'git_tests'
 
         # make notebook


### PR DESCRIPTION
Now you can edit note names alongside their content. 

Doing so is a two-step process in the back end:

1. Commit the content like normal
2. Rename (git mv) the note file and commit

Currently, git mv uses -f to ensure it works, but in the future, we'll probably want something more robust like branching or notifying the user that they should choose another name.

Related to issue #46. 